### PR TITLE
Remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 scapy
-argparse


### PR DESCRIPTION
`argparse` is a [standard module](https://github.com/HalilDeniz/Dosinator/blob/main/requirements.txt) and doesn't need to be installed.